### PR TITLE
Caching enabled for TallyVouchersList and one Bugfix

### DIFF
--- a/src/tendril/connectors/tally/stock.py
+++ b/src/tendril/connectors/tally/stock.py
@@ -383,7 +383,7 @@ class TallyStockPosition(TallyReport):
         r = etree.Element('DESC')
         sv = etree.SubElement(r, 'STATICVARIABLES')
         self._set_request_staticvariables(sv)
-        self._set_request_date(sv)
+        self._set_request_date(sv, dt=self._dt, end_dt=self._end_dt)
         tdl = etree.SubElement(r, 'TDL')
         tdlmessage = etree.SubElement(tdl, 'TDLMESSAGE')
         collection = etree.SubElement(tdlmessage, 'COLLECTION', ISMODIFY='No',

--- a/src/tendril/connectors/tally/vouchers.py
+++ b/src/tendril/connectors/tally/vouchers.py
@@ -225,7 +225,7 @@ class TallyVoucher(TallyElement):
 
 
 class TallyVouchersList(TallyReport):
-    _cachename = None
+    _cachename = 'TallyVouchersList'
     _header = TallyRequestHeader(1, 'Export', 'Data', 'Voucher Register')
 
     def __init__(self, company_name, dt=None, end_dt=None, filters=None):


### PR DESCRIPTION
- Caching was not enabled for TallyVouchersList [FIXED]
-  stock.TallyStockPosition _build_request_body method was not
  setting the start and end date in the XML request. Fixed and tested.

